### PR TITLE
Enable autocommit to avoid wrapping transaction

### DIFF
--- a/find_bad_toast
+++ b/find_bad_toast
@@ -36,6 +36,7 @@ upon the performance of plpgsql as a language.
 """
 def find_bad_toast(connect_string, table, pks):
     conn = psycopg2.connect(connect_string)
+    conn.autocommit = True
     
     ids_cur = conn.cursor()
     pk_cols = ', '.join(pks)


### PR DESCRIPTION
The script as written uses the psycopg2 defaults, which means autocommit will be False - i.e. every statement will run in a transaction thats left open.

That has various problems, but the biggest issue I ran into is that the first time the script finds a bad row it will stop working as its going to be stuck in a failed transaction thats not being rolled back.

I think it'd be sensible to just always set `autocommit = True` to avoid this. Thoughts?

(and thanks for the script btw!)